### PR TITLE
Document that value type must be default-constructible

### DIFF
--- a/cf/cfuture.h
+++ b/cf/cfuture.h
@@ -272,6 +272,8 @@ struct future_held_type<future<T>> {
 
 template<typename T>
 class future {
+  static_assert(std::is_default_constructible<T>::value, "T must be default-constructible");
+
   template<typename U>
   friend class promise;
 

--- a/test/future.cpp
+++ b/test/future.cpp
@@ -13,7 +13,11 @@ int foo(const cf::future<char>&);
 double foo1(cf::future<int>);
 cf::future<double> foo3(cf::future<int>);
 
-struct baz { };
+struct baz {
+  baz() = default;
+  baz(int v) : v_(v) {}
+  int v_;
+};
 struct test_struct {
   cf::unit bar1(cf::future<baz>) { return cf::unit(); }
 };
@@ -660,6 +664,13 @@ TEST_CASE("Make future functions") {
     REQUIRE(f.is_ready());
     REQUIRE(f.valid());
     REQUIRE(f.get() == 42);
+  }
+
+  SECTION("Make ready baz") {
+    cf::future<baz> f = cf::make_ready_future(baz{1});
+    REQUIRE(f.is_ready());
+    REQUIRE(f.valid());
+    REQUIRE(f.get().v_ == 1);
   }
 
   SECTION("Make excetion")


### PR DESCRIPTION
In contrast to `std::future`, value type for `cf::future` must be default-constructible, to construct `shared_state::value_`. It would be nice to get rid of this limitation altogether, in the mean time suggest adding a `static_assert` and a test.