### PR TITLE
Abandon previous future when assigned to

### DIFF
--- a/cf/cfuture.h
+++ b/cf/cfuture.h
@@ -749,6 +749,8 @@ public:
     : state_(std::move(other.state_)) {}
 
   promise& operator = (promise&& other) {
+    if (state_)
+      state_->abandon();
     state_ = std::move(other.state_);
     return *this;
   }

--- a/test/future.cpp
+++ b/test/future.cpp
@@ -160,6 +160,19 @@ TEST_CASE("Future") {
       }
     } // set value
 
+    SECTION("Assign promise") {
+      cf::promise<int> p1;
+      auto f1 = p1.get_future();
+
+      p1 = cf::promise<int>();
+      SECTION("Assigning to promise sets previous future") {
+        REQUIRE(f1.valid());
+      }
+      SECTION("Assigning to promise abandons previous future") {
+        REQUIRE_THROWS(f1.get());
+      }
+    } // assign promisbe
+
     SECTION("Set exception") {
       promise.set_exception(std::make_exception_ptr(std::logic_error("test")));
 


### PR DESCRIPTION
Without this cleanup check in the assignment operator the test case hangs forever as the previous future can never become ready.